### PR TITLE
Detect properly the documented option 'whitelistedResourcePathPatterns'

### DIFF
--- a/aem-classification-validator/src/main/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactory.java
+++ b/aem-classification-validator/src/main/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactory.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -46,7 +47,9 @@ public class AemClassificationValidatorFactory implements ValidatorFactory {
      * resource based maps. Also all other known protocols are supported */
     private static final String OPTION_MAPS = "maps";
     /** optional list of comma-separated resource path patterns (should be absolute) */
-    private static final String OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS = "whitelistedResourcePathsPatterns";
+    private static final String OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS = "whitelistedResourcePathPatterns";
+    private static final String OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS_OLD = "whitelistedResourcePathsPatterns";
+
     private static final Object OPTION_SEVERITIES_PER_CLASSIFICATION = "severitiesPerClassification";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AemClassificationValidatorFactory.class);
@@ -58,11 +61,23 @@ public class AemClassificationValidatorFactory implements ValidatorFactory {
         if (StringUtils.isBlank(mapUrls)) {
             throw new IllegalArgumentException("Mandatory option " + OPTION_MAPS + " missing!");
         }
-        String optionWhitelistedResourcePaths = settings.getOptions().get(OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS);
+        String optionWhitelistedResourcePaths = null;
+        if (settings.getOptions().containsKey(OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS_OLD)) {
+            LOGGER.warn("Deprecated option '{}' detected, please switch to the new key '{}' instead", OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS_OLD, OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS);
+            optionWhitelistedResourcePaths = settings.getOptions().get(OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS_OLD);
+        }
+        if (settings.getOptions().containsKey(OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS)) {
+            optionWhitelistedResourcePaths = settings.getOptions().get(OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS);
+        }
 
-        Collection<String> contentClassificationResourceTypeWhitelist = 
+        Collection<String> whitelistedResourcePaths = 
                 Optional.ofNullable(optionWhitelistedResourcePaths).map(op -> Arrays.asList(op.split(","))).orElse(Collections.emptyList());
 
+        try {
+            whitelistedResourcePaths.stream().forEach(AemClassificationValidatorFactory::validateResourcePathPattern);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("At least one value given in option " + OPTION_WHITELISTED_RESOURCE_PATH_PATTERNS + " is invalid", e);
+        }
         try {
             ContentClassificationMapper map = null;
             for (String mapUrl : mapUrls.split(",")) {
@@ -79,7 +94,7 @@ public class AemClassificationValidatorFactory implements ValidatorFactory {
             if (map == null) {
                 throw new IllegalArgumentException("At least one valid map must be given!");
             }
-            return new AemClassificationValidator(settings.getDefaultSeverity(), map, contentClassificationResourceTypeWhitelist,
+            return new AemClassificationValidator(settings.getDefaultSeverity(), map, whitelistedResourcePaths,
                     getSeverityPerClassification(settings.getOptions().get(OPTION_SEVERITIES_PER_CLASSIFICATION)));
         } catch (IOException e) {
             throw new IllegalStateException("Could not read from  " + mapUrls, e);
@@ -123,5 +138,14 @@ public class AemClassificationValidatorFactory implements ValidatorFactory {
         }
 
         return result;
+    }
+
+    static void validateResourcePathPattern(String resourcePathPattern) throws IllegalArgumentException {
+        Matcher matcher = Pattern.compile(resourcePathPattern).matcher("/");
+        matcher.matches();
+        if (!matcher.hitEnd()) {
+            // pattern does not allow a starting "/"
+            throw new IllegalArgumentException("The given resource path pattern " + resourcePathPattern + " will never match as it does not allow a path to start with '/' or matches all paths!");
+        }
     }
 }

--- a/aem-classification-validator/src/test/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactoryTest.java
+++ b/aem-classification-validator/src/test/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactoryTest.java
@@ -64,10 +64,25 @@ public class AemClassificationValidatorFactoryTest {
     }
 
     @Test
+    public void testValidateResourcePathPatternWithValidPatterns() {
+        AemClassificationValidatorFactory.validateResourcePathPattern("/libs");
+        AemClassificationValidatorFactory.validateResourcePathPattern("/libs/some/path");
+        AemClassificationValidatorFactory.validateResourcePathPattern(".*/test");
+    }
+
+    @Test
+    public void testValidateResourcePathPatternWithInvalidPatterns() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AemClassificationValidatorFactory.validateResourcePathPattern("relative/path"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AemClassificationValidatorFactory.validateResourcePathPattern("/"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AemClassificationValidatorFactory.validateResourcePathPattern("[^/].*"));
+    }
+
+    @Test
     public void testCreateValidator() {
         AemClassificationValidatorFactory factory = new AemClassificationValidatorFactory();
         Map<String, String> options = new HashMap<>();
         options.put("maps", "tccl:valid-classification.map");
+        // deprecated option for whitelisting
         options.put("whitelistedResourcePathsPatterns", "/resourceType1/.*,/resourceType2");
         options.put("severitiesPerClassification", "INTERNAL=DEBUG");
         ValidatorSettings settings = new ValidatorSettingsImpl(false, ValidationMessageSeverity.WARN, options);
@@ -79,6 +94,14 @@ public class AemClassificationValidatorFactoryTest {
         Map<ContentClassification, ValidationMessageSeverity> severitiesPerClassification = new HashMap<>();
         severitiesPerClassification.put(ContentClassification.INTERNAL, ValidationMessageSeverity.DEBUG);
         AemClassificationValidator expectedValidator = new AemClassificationValidator(ValidationMessageSeverity.WARN, map, whiteListedResourceTypes, severitiesPerClassification);
+        Assertions.assertEquals(expectedValidator, factory.createValidator(null, settings));
+        
+        options = new HashMap<>();
+        options.put("maps", "tccl:valid-classification.map");
+        // new option for whitelisting
+        options.put("whitelistedResourcePathPatterns", "/resourceType1/.*,/resourceType2");
+        options.put("severitiesPerClassification", "INTERNAL=DEBUG");
+        settings = new ValidatorSettingsImpl(false, ValidationMessageSeverity.WARN, options);
         Assertions.assertEquals(expectedValidator, factory.createValidator(null, settings));
     }
     


### PR DESCRIPTION
(while still supporting the old option
'whitelistedResourcePathsPatterns')

Validate given path patterns

This fixes #7
This fixes #8