### PR TITLE
support splitting "maps" parameters with whitespaces before/after the ","

### DIFF
--- a/aem-classification-validator/src/main/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactory.java
+++ b/aem-classification-validator/src/main/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactory.java
@@ -80,7 +80,7 @@ public class AemClassificationValidatorFactory implements ValidatorFactory {
         }
         try {
             ContentClassificationMapper map = null;
-            for (String mapUrl : mapUrls.split(",")) {
+            for (String mapUrl : mapUrls.split("\\s*,\\s*")) {
                 try (InputStream input = URLFactory.createURL(mapUrl).openStream()) {
                     if (map == null) {
                         map = new ContentClassificationMapperImpl(input, mapUrl);

--- a/aem-classification-validator/src/test/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactoryTest.java
+++ b/aem-classification-validator/src/test/java/biz/netcentric/filevault/validator/aem/classification/AemClassificationValidatorFactoryTest.java
@@ -103,6 +103,14 @@ public class AemClassificationValidatorFactoryTest {
         options.put("severitiesPerClassification", "INTERNAL=DEBUG");
         settings = new ValidatorSettingsImpl(false, ValidationMessageSeverity.WARN, options);
         Assertions.assertEquals(expectedValidator, factory.createValidator(null, settings));
+
+        // test with multiple validation maps including whitespaces in the maps string
+        options = new HashMap<>();
+        options.put("maps", "tccl:valid-classification.map,tccl:empty-map-1.map,\n  \t tccl:empty-map-2.map");
+        options.put("whitelistedResourcePathPatterns", "/resourceType1/.*,/resourceType2");
+        options.put("severitiesPerClassification", "INTERNAL=DEBUG");
+        settings = new ValidatorSettingsImpl(false, ValidationMessageSeverity.WARN, options);
+        Assertions.assertEquals(expectedValidator, factory.createValidator(null, settings));
     }
     
     private static final class ValidatorSettingsImpl implements ValidatorSettings {

--- a/aem-classification-validator/src/test/resources/empty-map-1.map
+++ b/aem-classification-validator/src/test/resources/empty-map-1.map
@@ -1,0 +1,1 @@
+# Empty map

--- a/aem-classification-validator/src/test/resources/empty-map-2.map
+++ b/aem-classification-validator/src/test/resources/empty-map-2.map
@@ -1,0 +1,1 @@
+# Empty map


### PR DESCRIPTION
to support more readable configuration sections like:

```xml
<maps>
  tccl:biz/netcentric/filevault/validator/maps/aem-classification-map-deprecations/coral2deprecations.map,
  tccl:biz/netcentric/filevault/validator/maps/aem-classification-map-deprecations/graniteuideprecations.map,
  tccl:biz/netcentric/filevault/validator/maps/aem-classification-map-repo-annotations.map
</maps>
```